### PR TITLE
Macro should play nice with built-in reduce functions

### DIFF
--- a/lib/soca/plugins/macro.rb
+++ b/lib/soca/plugins/macro.rb
@@ -18,7 +18,7 @@ module Soca
                 else
                  res += "#{line}\n"
                 end
-              end
+              end.strip
             end
         end
     end


### PR DESCRIPTION
Hey,

when using the 'macro' plugin before push, macro appends a trailing newline to a reduce function consisting of a single line with no trailing newline, such as:

```
_count
```

This becomes:

```
_count\n
```

thanks to the macro plugin. CouchDB does not recognize this as a built-in reduce function and pukes all over the place.

Single file, single line commit attached solves the issue.

Thanks,
Gabor
