### PR TITLE
I added a new flag to config.js called {"not_design": true} to allow non-design documents to be autopushed.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,8 +19,8 @@ GEM
       git (>= 1.2.5)
       rake
     jim (0.3.1)
-      downlow (~> 0.1.4)
       downlow (~> 0.1.3)
+      downlow (~> 0.1.4)
       fakeweb (>= 1.2.8)
       fssm
       fssm (~> 0.2.0)
@@ -31,8 +31,8 @@ GEM
       rake
       shoulda
       test-unit
-      thor (~> 0.14.4)
       thor
+      thor (~> 0.14.4)
       version_sorter (~> 1.1.0)
       version_sorter (~> 1.1.0)
       yajl-ruby

--- a/lib/soca/pusher.rb
+++ b/lib/soca/pusher.rb
@@ -56,7 +56,7 @@ module Soca
 
     def push_url
       raise "no app id specified in config" unless config['id']
-      "#{db_url}/_design/#{config['id']}"
+      config['not_design'] ? "#{db_url}/#{config['id']}" : "#{db_url}/_design/#{config['id']}"
     end
 
     def app_url


### PR DESCRIPTION
Modified soca to repurpose it for creating non-design docs that can be used for bundling data with a soca couchapp on a mobile device.

I wanted to use soca for packaging applications for couchbase which could require views or data to be seeded in any couch database on a mobile device with a structure/layout decided by the client. Take a look at https://github.com/kmalakoff/phonegap-couchbase-xplatform -> couch_automate.rb for how it works.

Basically, the developer works in their various soca directories, which get automatically updated to their desktop/laptop couchdb as they develop. Once they are happy, they just build and run in XCode because those changes have been automatically propagated to their Resources directory using couchpack (with couchwatcher).

It is a bit clunky in terms of creating a new .js file per document field, but this clunkiness is worth the power of using soca autopush!

I will write a blogpost to explain all of this in more detail.
