### PR TITLE
Allow https in env db_url

### DIFF
--- a/lib/soca/pusher.rb
+++ b/lib/soca/pusher.rb
@@ -45,7 +45,7 @@ module Soca
     end
 
     def db_url
-      if env =~ /^http\:\/\// # the env is actual a db_url
+      if env =~ /^https?\:\/\// # the env is actual a db_url
         env
       else
         env_config = config['couchapprc']['env'][env]


### PR DESCRIPTION
The regular expression to match absolute URLs should allow https as a protocol
